### PR TITLE
Improve long poll handling in node.js

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -94,7 +94,7 @@ mbedConnectorApi.prototype.makeRequest = function(requestData, userCallback,
   return request(requestObj, function(error, response, body) {
     requestCallback.call(_this, error, response, body, userCallback);
   });
-}
+};
 
 mbedConnectorApi.prototype.requestCallback = function(error, response, body,
                                                    callback) {

--- a/lib/notifications.js
+++ b/lib/notifications.js
@@ -42,8 +42,9 @@ mbedConnectorApi.prototype.getCallback = function(callback, options) {
                  'callback'),
     headers: {
       accept: 'application/json'
-    }
-  }
+    },
+    timeout: 31000
+  };
 
   this.makeRequest(requestData, function(error, data) {
     if (typeof callback === 'function') {
@@ -138,8 +139,7 @@ mbedConnectorApi.prototype.deleteCallback = function(callback, options) {
  */
 
 mbedConnectorApi.prototype.startLongPolling = function(callback, options) {
-  var firstPoll = true;
-  var waitingForFirstResponse = false;
+  var waitingForFirstResponse = true;
 
   if (!options) {
     options = {};
@@ -161,7 +161,7 @@ mbedConnectorApi.prototype.startLongPolling = function(callback, options) {
       Connection: 'keep-alive'
     },
     qs: {
-      'noWait': false
+      noWait: true
     }
   };
 
@@ -175,19 +175,18 @@ mbedConnectorApi.prototype.startLongPolling = function(callback, options) {
         }
       } else {
         console.log('ERROR: Long poll failed [Status ' + error.status + ']');
+
+        requestData.qs.noWait = false;
+        setTimeout(function() {
+          _this.longPollRequestObj = _this.makeRequest(requestData, poll, options);
+        }, 1000);
       }
     } else {
       if (data) {
         _this.handleNotifications(data);
       }
 
-      if (firstPoll) {
-        firstPoll = false;
-        waitingForFirstResponse = true;
-        requestData.qs.noWait = true;
-      } else {
-        requestData.qs.noWait = false;
-      }
+      requestData.qs.noWait = false;
 
       _this.longPollRequestObj = _this.makeRequest(requestData, poll, options);
 
@@ -204,7 +203,7 @@ mbedConnectorApi.prototype.startLongPolling = function(callback, options) {
     this.stopLongPolling();
   }
 
-  poll();
+  _this.longPollRequestObj = _this.makeRequest(requestData, poll, options);
 };
 
 


### PR DESCRIPTION
* Actually fail if first request fails.
* Allow to recover from failures later on.

For the first one, startLongPolling callback is always called w/o error object, even when the first actual request fails. Easy to verify by disabling internet connection.

Second one, I woke up to an `ERROR: Long poll failed [Status 500]` message in my server logs this morning, and after that the complete application is broken. This patch also adds a retry mechanism for that.

@bridadan 