### PR TITLE
Api annoyances, fix #15, #19, #20

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -46,6 +46,12 @@ var mbedConnectorApi = function(options) {
     restApiVersion: 'v2'
   };
 
+  if (typeof options === 'string') {
+    options = {
+      accessKey: options
+    };
+  }
+
   this.options = extend(true, {}, defaultOptions, options || {});
 
   this.asyncCallbacks = {};

--- a/lib/endpoints.js
+++ b/lib/endpoints.js
@@ -34,6 +34,10 @@ var mbedConnectorApi = require('./common');
  */
 
 mbedConnectorApi.prototype.getEndpoints = function(options, callback) {
+  if (typeof options === 'string') {
+    options = { parameters: { type: options } };
+  }
+
   options = extend(true, {}, this.options, options || {});
 
   var requestData = {
@@ -69,6 +73,8 @@ mbedConnectorApi.prototype.getEndpoints = function(options, callback) {
  */
 
 mbedConnectorApi.prototype.getResources = function(endpoint, options, callback) {
+  if (typeof endpoint === 'object' && endpoint.name) endpoint = endpoint.name;
+
   options = extend(true, {}, this.options, options || {});
 
   var requestData = {
@@ -111,6 +117,8 @@ mbedConnectorApi.prototype.getResourceValue = function(endpoint,
                                                     resource,
                                                     options,
                                                     callback) {
+  if (typeof endpoint === 'object' && endpoint.name) endpoint = endpoint.name;
+
   options = extend(true, {}, this.options, options || {});
 
   var requestData = {
@@ -158,6 +166,8 @@ mbedConnectorApi.prototype.putResourceValue = function(endpoint,
                                                     value,
                                                     options,
                                                     callback) {
+  if (typeof endpoint === 'object' && endpoint.name) endpoint = endpoint.name;
+
   options = extend(true, {}, this.options, options || {});
 
   var requestData = {
@@ -207,6 +217,8 @@ mbedConnectorApi.prototype.postResource = function(endpoint,
                                                 value,
                                                 options,
                                                 callback) {
+  if (typeof endpoint === 'object' && endpoint.name) endpoint = endpoint.name;
+
   options = extend(true, {}, this.options, options || {});
 
   var requestData = {
@@ -253,6 +265,8 @@ mbedConnectorApi.prototype.postResource = function(endpoint,
  */
 
 mbedConnectorApi.prototype.deleteEndpoint = function(endpoint, options, callback) {
+  if (typeof endpoint === 'object' && endpoint.name) endpoint = endpoint.name;
+
   options = extend(true, {}, this.options, options || {});
 
   var requestData = {

--- a/test/test-connector.js
+++ b/test/test-connector.js
@@ -44,6 +44,18 @@ mbedConnectorApi = new MbedConnectorApi({
   accessKey: accessKey
 });
 
+describe('mbedConnectorApi constructor', function() {
+  it('Should take an object as first argument', function() {
+    var a = new MbedConnectorApi({ accessKey: 'hoi' });
+    assert.equal(a.options.accessKey, 'hoi');
+  });
+  
+  it('Should also take string as first argument', function() {
+    var a = new MbedConnectorApi('hoi');
+    assert.equal(a.options.accessKey, 'hoi');
+  });
+});
+
 module.exports = function(mock, useCallback) {
   var config = {
     mock: mock,


### PR DESCRIPTION
See the relevant issues.

* Overload constructor to take strings as access key.
* Overload getEndpoints to take type as string.
* Overload resource calls to take device object as well as device name.

Depends on the options/callback arguments PR.

@bridadan 